### PR TITLE
Reimplement #1071

### DIFF
--- a/Content.Tests/DMProject/Tests/Loop/For.dm
+++ b/Content.Tests/DMProject/Tests/Loop/For.dm
@@ -9,6 +9,21 @@
 		counter++
 	ASSERT(counter == 3)
 
+	var/i = -1
+	for(i in 1 to 0) // An end bound lower than the start bound should not assign to i
+		continue
+	ASSERT(i == -1)
+
+	i = -1
+	for(i in list()) // This should though!
+		continue
+	ASSERT(i == null)
+
+	i = -1
+	for(i in list(1)) // Even ends up being null if the list isn't empty
+		continue
+	ASSERT(i == null)
+
 	counter = 0
 	var/j = 1
 	for(,j <= 3,j++)

--- a/DMCompiler/DM/DMProc.cs
+++ b/DMCompiler/DM/DMProc.cs
@@ -310,11 +310,19 @@ namespace DMCompiler.DM {
             WriteOpcode(DreamProcOpcode.CreateRangeEnumerator);
         }
 
-        public void Enumerate() {
+        public void Enumerate(DMReference reference) {
             if (_loopStack?.TryPeek(out var peek) ?? false) {
-                // Conditionally pushes one value
-                GrowStack(1);
                 WriteOpcode(DreamProcOpcode.Enumerate);
+                WriteReference(reference);
+                WriteLabel($"{peek}_end");
+            } else {
+                DMCompiler.ForcedError(Location, "Cannot peek empty loop stack");
+            }
+        }
+
+        public void EnumerateNoAssign() {
+            if (_loopStack?.TryPeek(out var peek) ?? false) {
+                WriteOpcode(DreamProcOpcode.EnumerateNoAssign);
                 WriteLabel($"{peek}_end");
             } else {
                 DMCompiler.ForcedError(Location, "Cannot peek empty loop stack");
@@ -667,12 +675,6 @@ namespace DMCompiler.DM {
 
         public void Assign(DMReference reference) {
             WriteOpcode(DreamProcOpcode.Assign);
-            WriteReference(reference);
-        }
-
-        public void AssignPop(DMReference reference) {
-            ShrinkStack(1);
-            WriteOpcode(DreamProcOpcode.AssignPop);
             WriteReference(reference);
         }
 

--- a/DMCompiler/DM/Visitors/DMProcBuilder.cs
+++ b/DMCompiler/DM/Visitors/DMProcBuilder.cs
@@ -515,17 +515,15 @@ namespace DMCompiler.DM.Visitors {
                 string endLabel2 = _proc.NewLabelName();
 
                 DMReference outputRef = lValue.EmitReference(_dmObject, _proc, endLabel, DMExpression.ShortCircuitMode.PopNull);
-                _proc.Enumerate();
-                _proc.AssignPop(outputRef);
+                _proc.Enumerate(outputRef);
                 _proc.Jump(endLabel2);
 
                 _proc.AddLabel(endLabel);
-                _proc.Enumerate();
+                _proc.EnumerateNoAssign();
                 _proc.AddLabel(endLabel2);
             } else {
                 DMReference outputRef = lValue.EmitReference(_dmObject, _proc, null);
-                _proc.Enumerate();
-                _proc.AssignPop(outputRef);
+                _proc.Enumerate(outputRef);
             }
         }
 

--- a/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
+++ b/OpenDreamRuntime/Procs/DMOpcodeHandlers.cs
@@ -57,14 +57,6 @@ namespace OpenDreamRuntime.Procs {
             return null;
         }
 
-        public static ProcStatus? AssignPop(DMProcState state) {
-            DMReference reference = state.ReadReference();
-            DreamValue value = state.Pop();
-
-            state.AssignReference(reference, value);
-            return null;
-        }
-
         public static ProcStatus? CreateList(DMProcState state) {
             int size = state.ReadInt();
             var list = state.Proc.ObjectTree.CreateList(size);
@@ -224,14 +216,21 @@ namespace OpenDreamRuntime.Procs {
 
         public static ProcStatus? Enumerate(DMProcState state) {
             IDreamValueEnumerator enumerator = state.EnumeratorStack.Peek();
+            DMReference outputRef = state.ReadReference();
             int jumpToIfFailure = state.ReadInt();
-            bool successfulEnumeration = enumerator.MoveNext();
 
-            if (successfulEnumeration) {
-                state.Push(enumerator.Current);
-            } else {
+            if (!enumerator.Enumerate(state, outputRef))
                 state.Jump(jumpToIfFailure);
-            }
+
+            return null;
+        }
+
+        public static ProcStatus? EnumerateNoAssign(DMProcState state) {
+            IDreamValueEnumerator enumerator = state.EnumeratorStack.Peek();
+            int jumpToIfFailure = state.ReadInt();
+
+            if (!enumerator.Enumerate(state, null))
+                state.Jump(jumpToIfFailure);
 
             return null;
         }

--- a/OpenDreamRuntime/Procs/DMProc.cs
+++ b/OpenDreamRuntime/Procs/DMProc.cs
@@ -185,12 +185,12 @@ namespace OpenDreamRuntime.Procs {
             {DreamProcOpcode.DereferenceIndex, DMOpcodeHandlers.DereferenceIndex},
             {DreamProcOpcode.DereferenceCall, DMOpcodeHandlers.DereferenceCall},
             {DreamProcOpcode.PopReference, DMOpcodeHandlers.PopReference},
-            {DreamProcOpcode.AssignPop, DMOpcodeHandlers.AssignPop},
             {DreamProcOpcode.BitShiftLeftReference,DMOpcodeHandlers.BitShiftLeftReference},
             {DreamProcOpcode.BitShiftRightReference, DMOpcodeHandlers.BitShiftRightReference},
             {DreamProcOpcode.Try, DMOpcodeHandlers.Try},
             {DreamProcOpcode.TryNoValue, DMOpcodeHandlers.TryNoValue},
             {DreamProcOpcode.EndTry, DMOpcodeHandlers.EndTry},
+            {DreamProcOpcode.EnumerateNoAssign, DMOpcodeHandlers.EnumerateNoAssign}
         };
 
         private static readonly OpcodeHandler?[] _opcodeHandlers;

--- a/OpenDreamRuntime/Procs/DreamEnumerators.cs
+++ b/OpenDreamRuntime/Procs/DreamEnumerators.cs
@@ -73,8 +73,6 @@ namespace OpenDreamRuntime.Procs {
 
         public bool Enumerate(DMProcState state, DMReference? reference) {
             _current++;
-            if (_current >= _dreamValueArray.Length)
-                return false;
 
             bool success = _current < _dreamValueArray.Length;
             if (reference != null)

--- a/OpenDreamRuntime/Procs/DreamEnumerators.cs
+++ b/OpenDreamRuntime/Procs/DreamEnumerators.cs
@@ -1,10 +1,9 @@
 ﻿using OpenDreamRuntime.Objects;
+using OpenDreamShared.Dream.Procs;
 
 namespace OpenDreamRuntime.Procs {
     internal interface IDreamValueEnumerator {
-        public DreamValue Current { get; }
-
-        public bool MoveNext();
+        public bool Enumerate(DMProcState state, DMReference? reference);
     }
 
     /// <summary>
@@ -12,8 +11,6 @@ namespace OpenDreamRuntime.Procs {
     /// <code>for (var/i in 1 to 10 step 2)</code>
     /// </summary>
     sealed class DreamValueRangeEnumerator : IDreamValueEnumerator {
-        public DreamValue Current => new DreamValue(_current);
-
         private float _current;
         private readonly float _end;
         private readonly float _step;
@@ -24,10 +21,14 @@ namespace OpenDreamRuntime.Procs {
             _step = step;
         }
 
-        public bool MoveNext() {
+        public bool Enumerate(DMProcState state, DMReference? reference) {
             _current += _step;
 
-            return (_step > 0) ? _current <= _end : _current >= _end;
+            bool successful = (_step > 0) ? _current <= _end : _current >= _end;
+            if (successful && reference != null) // Only assign if it was successful
+                state.AssignReference(reference.Value, new DreamValue(_current));
+
+            return successful;
         }
     }
 
@@ -35,8 +36,6 @@ namespace OpenDreamRuntime.Procs {
     /// Enumerates over an IEnumerable of DreamObjects, possibly filtering for a certain type
     /// </summary>
     sealed class DreamObjectEnumerator : IDreamValueEnumerator {
-        public DreamValue Current => new DreamValue(_dreamObjectEnumerator.Current);
-
         private readonly IEnumerator<DreamObject> _dreamObjectEnumerator;
         private readonly IDreamObjectTree.TreeEntry? _filterType;
 
@@ -45,15 +44,18 @@ namespace OpenDreamRuntime.Procs {
             _filterType = filterType;
         }
 
-        public bool MoveNext() {
-            bool hasNext = _dreamObjectEnumerator.MoveNext();
+        public bool Enumerate(DMProcState state, DMReference? reference) {
+            bool success = _dreamObjectEnumerator.MoveNext();
             if (_filterType != null) {
-                while (hasNext && !_dreamObjectEnumerator.Current.IsSubtypeOf(_filterType)) {
-                    hasNext = _dreamObjectEnumerator.MoveNext();
+                while (success && !_dreamObjectEnumerator.Current.IsSubtypeOf(_filterType)) {
+                    success = _dreamObjectEnumerator.MoveNext();
                 }
             }
 
-            return hasNext;
+            // Assign regardless of success
+            if (reference != null)
+                state.AssignReference(reference.Value, new DreamValue(_dreamObjectEnumerator.Current));
+            return success;
         }
     }
 
@@ -62,32 +64,22 @@ namespace OpenDreamRuntime.Procs {
     /// <code>for (var/i in list(1, 2, 3))</code>
     /// </summary>
     sealed class DreamValueArrayEnumerator : IDreamValueEnumerator {
-        private readonly DreamValue[]? _dreamValueArray;
+        private readonly DreamValue[] _dreamValueArray;
         private int _current = -1;
 
-        public DreamValueArrayEnumerator(DreamValue[]? dreamValueArray) {
+        public DreamValueArrayEnumerator(DreamValue[] dreamValueArray) {
             _dreamValueArray = dreamValueArray;
         }
 
-        public DreamValue Current {
-            get {
-                if (_dreamValueArray == null)
-                    return DreamValue.Null;
-                if (_current < _dreamValueArray.Length)
-                    return _dreamValueArray[_current];
-                return DreamValue.Null;
-            }
-        }
-
-        public bool MoveNext() {
-            if (_dreamValueArray == null)
-                return false;
-
+        public bool Enumerate(DMProcState state, DMReference? reference) {
             _current++;
             if (_current >= _dreamValueArray.Length)
                 return false;
 
-            return true;
+            bool success = _current < _dreamValueArray.Length;
+            if (reference != null)
+                state.AssignReference(reference.Value, success ? _dreamValueArray[_current] : DreamValue.Null); // Assign regardless of success
+            return success;
         }
     }
 
@@ -96,37 +88,30 @@ namespace OpenDreamRuntime.Procs {
     /// <code>for (var/obj/item/I in contents)</code>
     /// </summary>
     sealed class FilteredDreamValueArrayEnumerator : IDreamValueEnumerator {
-        private readonly DreamValue[]? _dreamValueArray;
+        private readonly DreamValue[] _dreamValueArray;
         private readonly IDreamObjectTree.TreeEntry _filterType;
         private int _current = -1;
 
-        public FilteredDreamValueArrayEnumerator(DreamValue[]? dreamValueArray, IDreamObjectTree.TreeEntry filterType) {
+        public FilteredDreamValueArrayEnumerator(DreamValue[] dreamValueArray, IDreamObjectTree.TreeEntry filterType) {
             _dreamValueArray = dreamValueArray;
             _filterType = filterType;
         }
 
-        public DreamValue Current {
-            get {
-                if (_dreamValueArray == null)
-                    return DreamValue.Null;
-                if (_current < _dreamValueArray.Length)
-                    return _dreamValueArray[_current];
-                return DreamValue.Null;
-            }
-        }
-
-        public bool MoveNext() {
-            if (_dreamValueArray == null)
-                return false;
-
+        public bool Enumerate(DMProcState state, DMReference? reference) {
             do {
                 _current++;
-                if (_current >= _dreamValueArray.Length)
+                if (_current >= _dreamValueArray.Length) {
+                    if (reference != null)
+                        state.AssignReference(reference.Value, DreamValue.Null);
                     return false;
+                }
 
                 DreamValue value = _dreamValueArray[_current];
-                if (value.TryGetValueAsDreamObjectOfType(_filterType, out _))
+                if (value.TryGetValueAsDreamObjectOfType(_filterType, out _)) {
+                    if (reference != null)
+                        state.AssignReference(reference.Value, value);
                     return true;
+                }
             } while (true);
         }
     }
@@ -145,24 +130,19 @@ namespace OpenDreamRuntime.Procs {
             _filterType = filterType;
         }
 
-        public DreamValue Current {
-            get {
-                if (_current < _atomManager.AtomCount)
-                    return new(_atomManager.GetAtom(_current));
-                return DreamValue.Null;
-            }
-        }
-
-        public bool MoveNext() {
+        public bool Enumerate(DMProcState state, DMReference? reference) {
             do {
                 _current++;
-                if (_current >= _atomManager.AtomCount)
+                if (_current >= _atomManager.AtomCount) {
+                    if (reference != null)
+                        state.AssignReference(reference.Value, DreamValue.Null);
                     return false;
+                }
 
-                if (_filterType != null) {
-                    if (_atomManager.GetAtom(_current).IsSubtypeOf(_filterType))
-                        return true;
-                } else {
+                DreamObject atom = _atomManager.GetAtom(_current);
+                if (_filterType == null || atom.IsSubtypeOf(_filterType)) {
+                    if (reference != null)
+                        state.AssignReference(reference.Value, new DreamValue(atom));
                     return true;
                 }
             } while (true);

--- a/OpenDreamRuntime/Procs/ProcDecoder.cs
+++ b/OpenDreamRuntime/Procs/ProcDecoder.cs
@@ -92,7 +92,6 @@ public struct ProcDecoder {
 
             case DreamProcOpcode.Call:
             case DreamProcOpcode.Assign:
-            case DreamProcOpcode.AssignPop:
             case DreamProcOpcode.Append:
             case DreamProcOpcode.Remove:
             case DreamProcOpcode.Combine:
@@ -113,7 +112,7 @@ public struct ProcDecoder {
             case DreamProcOpcode.Input:
                 return (opcode, ReadReference(), ReadReference());
 
-            case DreamProcOpcode.Enumerate:
+            case DreamProcOpcode.EnumerateNoAssign:
             case DreamProcOpcode.CreateList:
             case DreamProcOpcode.CreateAssociativeList:
             case DreamProcOpcode.CreateFilteredListEnumerator:
@@ -141,6 +140,7 @@ public struct ProcDecoder {
             case DreamProcOpcode.JumpIfNullDereference:
             case DreamProcOpcode.JumpIfTrueReference:
             case DreamProcOpcode.JumpIfFalseReference:
+            case DreamProcOpcode.Enumerate:
                 return (opcode, ReadReference(), ReadInt());
 
             case DreamProcOpcode.Try:

--- a/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
+++ b/OpenDreamShared/Dream/Procs/DreamProcOpcode.cs
@@ -112,12 +112,13 @@ namespace OpenDreamShared.Dream.Procs {
         DereferenceIndex = 0x69,
         DereferenceCall = 0x6A,
         PopReference = 0x6B,
-        AssignPop = 0x6C,
+        //0x6C
         BitShiftLeftReference = 0x6D,
         BitShiftRightReference = 0x6E,
         Try = 0x6F,
         TryNoValue = 0x70,
         EndTry = 0x71,
+        EnumerateNoAssign = 0x72
     }
 
     public enum DreamProcOpcodeParameterType {


### PR DESCRIPTION
Reimplements https://github.com/OpenDreamProject/OpenDream/pull/1071

Doesn't differ much from the original PR. The `AssignPop` opcode was replaced with an `EnumerateNoAssign` opcode that will enumerate but not assign to any DMReference.